### PR TITLE
 feat/freeze-guest-when-host-finished

### DIFF
--- a/frontend/app/src/main/java/com/littlestudio/data/api/ServiceApi.java
+++ b/frontend/app/src/main/java/com/littlestudio/data/api/ServiceApi.java
@@ -39,6 +39,9 @@ public interface ServiceApi {
     @POST("/drawing/join")
     Call<ResponseBody> joinDrawing(@Body DrawingJoinRequestDto request);
 
+    @POST("/drawing/{id}/wait")
+    Call<Void> finishDrawing(@Path("id") int id);
+
     @POST("/drawing/{id}/submit")
     Call<DrawingViewResponseDto> submitDrawing(@Path("id") int id, @Body DrawingSubmitRequestDto request);
 

--- a/frontend/app/src/main/java/com/littlestudio/data/datasource/DrawingDataSource.java
+++ b/frontend/app/src/main/java/com/littlestudio/data/datasource/DrawingDataSource.java
@@ -22,6 +22,8 @@ public interface DrawingDataSource {
 
     void joinDrawing(DrawingJoinRequestDto request, Callback<ResponseBody> callback);
 
+    void finishDrawing(int id, Callback callback);
+
     void submitDrawing(int id, DrawingSubmitRequestDto request, Callback callback);
 
     void realTimeDrawing(DrawingRealTimeRequestDto request, Callback callback);

--- a/frontend/app/src/main/java/com/littlestudio/data/datasource/DrawingRemoteDataSource.java
+++ b/frontend/app/src/main/java/com/littlestudio/data/datasource/DrawingRemoteDataSource.java
@@ -77,6 +77,16 @@ public class DrawingRemoteDataSource implements DrawingDataSource {
     }
 
     @Override
+    public void finishDrawing(int id, Callback callback) {
+        try {
+            serviceApi.finishDrawing(id).enqueue(callback);
+        } catch (Exception e) {
+            e.printStackTrace();
+            callback.onFailure(null, e);
+        }
+    }
+
+    @Override
     public void submitDrawing(int id, DrawingSubmitRequestDto request, Callback callback) {
         try {
             serviceApi.submitDrawing(id, request).enqueue(callback);

--- a/frontend/app/src/main/java/com/littlestudio/data/dto/DrawingJoinResponseDto.java
+++ b/frontend/app/src/main/java/com/littlestudio/data/dto/DrawingJoinResponseDto.java
@@ -4,7 +4,7 @@ import java.util.ArrayList;
 
 
 public class DrawingJoinResponseDto {
-
+    public int drawing_id;
     public ArrayList<String> participants;
 
     public DrawingJoinResponseDto(){

--- a/frontend/app/src/main/java/com/littlestudio/data/repository/DrawingRepository.java
+++ b/frontend/app/src/main/java/com/littlestudio/data/repository/DrawingRepository.java
@@ -28,8 +28,8 @@ public class DrawingRepository {
     private final DrawingDataSource remoteDataSource;
     private final DrawingMapper drawingMapper;
 
-    public static DrawingRepository getInstance(DrawingDataSource remoteDataSource, DrawingMapper drawingMapper){
-        if (instance == null){
+    public static DrawingRepository getInstance(DrawingDataSource remoteDataSource, DrawingMapper drawingMapper) {
+        if (instance == null) {
             synchronized (DrawingRepository.class) {
                 if (instance == null) {
                     instance = new DrawingRepository(remoteDataSource, drawingMapper);
@@ -62,6 +62,7 @@ public class DrawingRepository {
             }
         });
     }
+
     public void getDrawing(int id, final Callback<Drawing> callback) {
         remoteDataSource.getDrawing(id, new Callback<DrawingViewResponseDto>() {
             @Override
@@ -76,6 +77,24 @@ public class DrawingRepository {
 
             @Override
             public void onFailure(Call<DrawingViewResponseDto> call, Throwable t) {
+                callback.onFailure(null, t);
+            }
+        });
+    }
+
+    public void finishDrawing(int id, final Callback callback) {
+        remoteDataSource.finishDrawing(id, new Callback<ResponseBody>() {
+            @Override
+            public void onResponse(Call<ResponseBody> call, Response<ResponseBody> response) {
+                if (response.isSuccessful() && response.body() != null) {
+                    callback.onResponse(null, null);
+                } else {
+                    callback.onFailure(null, new Throwable("Unsuccessful response"));
+                }
+            }
+
+            @Override
+            public void onFailure(Call<ResponseBody> call, Throwable t) {
                 callback.onFailure(null, t);
             }
         });
@@ -160,6 +179,7 @@ public class DrawingRepository {
             }
         });
     }
+
     public void startDrawing(DrawingStartRequestDto request, final Callback callback) {
 
         remoteDataSource.startDrawing(request, new Callback<ResponseBody>() {
@@ -174,6 +194,7 @@ public class DrawingRepository {
                     callback.onFailure(null, new Throwable("Unsuccessful response"));
                 }
             }
+
             @Override
             public void onFailure(Call call, Throwable t) {
                 Log.e("hei", "jfke");

--- a/frontend/app/src/main/java/com/littlestudio/ui/ImageActivity.java
+++ b/frontend/app/src/main/java/com/littlestudio/ui/ImageActivity.java
@@ -34,6 +34,7 @@ public class ImageActivity extends AppCompatActivity {
     DrawingRepository drawingRepository;
     UserRepository userRepository;
     private int selectedImageViewId;
+    private int drawingId;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -50,11 +51,17 @@ public class ImageActivity extends AppCompatActivity {
                 UserLocalDataSource.getInstance(getApplicationContext())
         );
 
-        int drawingId = getIntent().getIntExtra(IntentExtraKey.DRAWING_ID, 0);
+        findViewById(com.littlestudio.R.id.image_close_drawing).setOnClickListener(v -> {
+            finish();
+        });
+    }
+
+    @Override
+    protected void onResume() {
+        super.onResume();
+
+        drawingId = getIntent().getIntExtra(IntentExtraKey.DRAWING_ID, 0);
         String imageUrl = getIntent().getStringExtra(IntentExtraKey.DRAWING_IMAGE_URL);
-        String dabUrl = getIntent().getStringExtra(IntentExtraKey.DRAWING_DAB_URL);
-        String jumpingUrl = getIntent().getStringExtra(IntentExtraKey.DRAWING_JUMPING_URL);
-        String zombieUrl = getIntent().getStringExtra(IntentExtraKey.DRAWING_ZOMBIE_URL);
 
         ImageView imageView = findViewById(R.id.image_view);
         Glide.with(this).load(imageUrl).into(imageView);
@@ -67,29 +74,11 @@ public class ImageActivity extends AppCompatActivity {
         });
 
         ImageView dabImageView = findViewById(R.id.dab_image_view);
-        Glide.with(this).load(dabUrl).into(dabImageView);
-        dabImageView.setOnClickListener(v -> {
-            onImageViewClicked(dabImageView.getId());
-            Glide.with(this).load(dabUrl).into(imageView);
-        });
-
         ImageView jumpingImageView = findViewById(R.id.jumping_image_view);
-        Glide.with(this).load(jumpingUrl).into(jumpingImageView);
-        jumpingImageView.setOnClickListener(v -> {
-            onImageViewClicked(jumpingImageView.getId());
-            Glide.with(this).load(jumpingUrl).into(imageView);
-        });
-
         ImageView zombieImageView = findViewById(R.id.zombie_image_view);
-        Glide.with(this).load(zombieUrl).into(zombieImageView);
-        zombieImageView.setOnClickListener(v -> {
-            onImageViewClicked(zombieImageView.getId());
-            Glide.with(this).load(zombieUrl).into(imageView);
-        });
 
         selectedImageViewId = originalImageView.getId(); // default to original image
         setForeground(selectedImageViewId, R.drawable.orange_border_thin);
-
         drawingRepository.getDrawing(drawingId, new Callback<Drawing>() {
             @Override
             public void onResponse(Call<Drawing> call, Response<Drawing> response) {
@@ -100,6 +89,28 @@ public class ImageActivity extends AppCompatActivity {
                 TextView participants = findViewById(R.id.gallery_detail_participants);
                 title.setText(drawing.title);
                 description.setText(drawing.description);
+
+                String dabUrl = drawing.gif_dab_url;
+                String jumpingUrl = drawing.gif_jumping_url;
+                String zombieUrl = drawing.gif_zombie_url;
+
+                Glide.with(getApplication()).load(dabUrl).into(dabImageView);
+                dabImageView.setOnClickListener(v -> {
+                    onImageViewClicked(dabImageView.getId());
+                    Glide.with(getApplication()).load(dabUrl).into(imageView);
+                });
+
+                Glide.with(getApplication()).load(jumpingUrl).into(jumpingImageView);
+                jumpingImageView.setOnClickListener(v -> {
+                    onImageViewClicked(jumpingImageView.getId());
+                    Glide.with(getApplication()).load(jumpingUrl).into(imageView);
+                });
+
+                Glide.with(getApplication()).load(zombieUrl).into(zombieImageView);
+                zombieImageView.setOnClickListener(v -> {
+                    onImageViewClicked(zombieImageView.getId());
+                    Glide.with(getApplication()).load(zombieUrl).into(imageView);
+                });
 
                 SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
                 String createOn = dateFormat.format(drawing.created_at);
@@ -116,10 +127,6 @@ public class ImageActivity extends AppCompatActivity {
             public void onFailure(Call<Drawing> call, Throwable t) {
                 Toast.makeText(getApplicationContext(), ErrorMessage.DEFAULT, Toast.LENGTH_SHORT).show();
             }
-        });
-
-        findViewById(com.littlestudio.R.id.image_close_drawing).setOnClickListener(v -> {
-            finish();
         });
     }
 

--- a/frontend/app/src/main/java/com/littlestudio/ui/MainActivity.java
+++ b/frontend/app/src/main/java/com/littlestudio/ui/MainActivity.java
@@ -188,9 +188,11 @@ public class MainActivity extends AppCompatActivity implements BottomNavigationV
                 @Override
                 public void onResponse(Call<DrawingJoinResponseDto> call, Response<DrawingJoinResponseDto> response) {
                     ArrayList<String> participants = response.body().participants;
+                    int drawingId = response.body().drawing_id;
                     intent.putExtra(IntentExtraKey.PARTICIPANTS, participants);
                     intent.putExtra(IntentExtraKey.INVITATION_CODE, invitationCode);
                     intent.putExtra(IntentExtraKey.HOST_CODE, false);
+                    intent.putExtra(IntentExtraKey.DRAWING_ID, drawingId);
                     startActivityForResult(intent, REQUEST_CODE);
                     alertDialog.dismiss();
                 }

--- a/frontend/app/src/main/java/com/littlestudio/ui/drawing/WaitingRoomActivity.java
+++ b/frontend/app/src/main/java/com/littlestudio/ui/drawing/WaitingRoomActivity.java
@@ -68,7 +68,7 @@ public class WaitingRoomActivity extends AppCompatActivity {
         );
 
         String invitationCode = getIntent().getStringExtra(IntentExtraKey.INVITATION_CODE);
-        int drawingId = getIntent().getIntExtra(IntentExtraKey.DRAWING_ID, 0);
+        drawingId = getIntent().getIntExtra(IntentExtraKey.DRAWING_ID, 0);
         TextView invitationCodeTextView = findViewById(R.id.invitation_code);
         invitationCodeTextView.setText(invitationCode);
 

--- a/frontend/app/src/main/res/layout/activity_drawing.xml
+++ b/frontend/app/src/main/res/layout/activity_drawing.xml
@@ -158,4 +158,41 @@
         app:layout_constraintBottom_toTopOf="@id/image_sketchbook"
         app:layout_constraintEnd_toEndOf="parent"/>
 
+    <LinearLayout
+        android:id="@+id/loading_indicator"
+        android:layout_width="match_parent"
+        android:layout_height="match_parent"
+        android:alpha="0.8"
+        android:background="@color/color_white"
+        android:gravity="center"
+        android:orientation="vertical"
+        android:visibility="gone">
+
+        <ProgressBar
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="80dp"
+            android:indeterminate="true"
+            android:indeterminateDrawable="@drawable/circular_progress"
+            android:indeterminateTint="@color/orange" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="24dp"
+            android:text="Loading..."
+            android:textAlignment="center"
+            android:textSize="32dp" />
+
+        <TextView
+            android:layout_width="300dp"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="8dp"
+            android:text="Please wait until your character is learning some dance moves! \n It may take a few minutes."
+            android:textAlignment="center"
+            android:textSize="20dp" />
+
+    </LinearLayout>
+
+
 </androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
<!-- 기능 소개를 간단히 해주세요. -->
<!-- 테스트 URL 이 있다면 적어주세요. -->
# What is this PR? 🔍
- 호스트가 [Finish] 버튼을 누르면 게스트 화면을 프리즈 하기
 
    - 호스트가 그림을 제출할 때까지 로딩 화면 보여주기
    
- 그림 제출 이후에 게스트가 갤러리 상세 화면으로 이동했을 때, 그림의 일부 정보가 표시되지 않는 문제 해결

<!-- 개발 내용을 자세히 적어주세요. -->
# Changes 📝
- `finishDrawing` API 추가
- 호스트가 [Finish] 버튼을 누르면 `finishDrawing` API 호출하기
- 게스트일 때, 서버에서 waiting 이벤트가 오면 로딩 화면 보여주기
- `joinDrawing` API의 응답으로 내려온 `drawing_id` 를 받아 Intent 로 갤러리 상세 화면에 전달하기

<!-- 작업한 내용을 보여주는 이미지가 있다면 첨부해주세요. -->
<!--
# Screenshot 📷
-->
